### PR TITLE
Add ATS-friendly resume builder - 1st part

### DIFF
--- a/DraftMe.xcodeproj/project.pbxproj
+++ b/DraftMe.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		8EF3EF662E771F420082EB25 /* CanvasViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF3EF652E771F3D0082EB25 /* CanvasViewModel.swift */; };
 		8EF3EF682E771F520082EB25 /* CanvasState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF3EF672E771F500082EB25 /* CanvasState.swift */; };
 		8EF3EF6B2E77220B0082EB25 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF3EF6A2E7722060082EB25 /* MenuView.swift */; };
+		8EF3EF882E7873040082EB25 /* PDFGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF3EF872E7873010082EB25 /* PDFGenerator.swift */; };
+		8EFFB3A52E86FE7E00ADF8C5 /* Resume.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EFFB3A32E86FE7E00ADF8C5 /* Resume.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +57,8 @@
 		8EF3EF652E771F3D0082EB25 /* CanvasViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewModel.swift; sourceTree = "<group>"; };
 		8EF3EF672E771F500082EB25 /* CanvasState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasState.swift; sourceTree = "<group>"; };
 		8EF3EF6A2E7722060082EB25 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
+		8EF3EF872E7873010082EB25 /* PDFGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFGenerator.swift; sourceTree = "<group>"; };
+		8EFFB3A32E86FE7E00ADF8C5 /* Resume.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resume.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -187,6 +191,8 @@
 		8EF3EF692E7721F70082EB25 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				8EFFB3A42E86FE7E00ADF8C5 /* Models */,
+				8EF3EF872E7873010082EB25 /* PDFGenerator.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -197,6 +203,14 @@
 				8EF3EF6A2E7722060082EB25 /* MenuView.swift */,
 			);
 			path = Menu;
+			sourceTree = "<group>";
+		};
+		8EFFB3A42E86FE7E00ADF8C5 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				8EFFB3A32E86FE7E00ADF8C5 /* Resume.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -347,7 +361,9 @@
 				8EF3EF682E771F520082EB25 /* CanvasState.swift in Sources */,
 				8EF3EF642E771F3A0082EB25 /* CanvasView.swift in Sources */,
 				8EF3EF6B2E77220B0082EB25 /* MenuView.swift in Sources */,
+				8EF3EF882E7873040082EB25 /* PDFGenerator.swift in Sources */,
 				8EF3EF5F2E771F1D0082EB25 /* TemplatesViewModel.swift in Sources */,
+				8EFFB3A52E86FE7E00ADF8C5 /* Resume.swift in Sources */,
 				8EF3EF052E7715C10082EB25 /* DraftMeApp.swift in Sources */,
 				8EF3EF5D2E771F0F0082EB25 /* TemplateView.swift in Sources */,
 				8EF3EF612E771F260082EB25 /* TemplatesState.swift in Sources */,

--- a/DraftMe/Core/Models/Resume.swift
+++ b/DraftMe/Core/Models/Resume.swift
@@ -1,0 +1,120 @@
+//
+//  Resume.swift
+//  DraftMe
+//
+//  Moved to Core/Models for reuse across features.
+//
+
+import Foundation
+
+struct Resume: Sendable, Codable, Equatable {
+    var basics: Basics
+    var summary: String
+    var experience: [Experience]
+    var education: [Education]
+    var skills: [String]
+    var certifications: [String]
+    var projects: [Project]
+}
+
+struct Basics: Sendable, Codable, Equatable {
+    var fullName: String
+    var title: String
+    var email: String
+    var phone: String
+    var location: String
+    var website: String
+    var linkedin: String
+    var github: String
+}
+
+struct Experience: Sendable, Codable, Equatable, Identifiable {
+    var id: UUID = .init()
+    var role: String
+    var company: String
+    var location: String
+    var startDate: String
+    var endDate: String
+    var bullets: [String]
+}
+
+struct Education: Sendable, Codable, Equatable, Identifiable {
+    var id: UUID = .init()
+    var institution: String
+    var degree: String
+    var startDate: String
+    var endDate: String
+}
+
+struct Project: Sendable, Codable, Equatable, Identifiable {
+    var id: UUID = .init()
+    var name: String
+    var description: String
+    var highlights: [String]
+}
+
+extension Resume {
+    static var placeholder: Resume {
+        .init(
+            basics: .init(
+                fullName: "Alex Johnson",
+                title: "Senior iOS Engineer",
+                email: "alex.johnson@example.com",
+                phone: "+44 7700 900123",
+                location: "London, UK",
+                website: "alexjohnson.dev",
+                linkedin: "linkedin.com/in/alexjohnson",
+                github: "github.com/alexjohnson"
+            ),
+            summary: "Senior iOS Engineer with 8+ years building accessible, high-performance apps. Led teams, shipped at scale, and improved reliability and developer velocity.",
+            experience: [
+                .init(
+                    role: "Lead iOS Engineer",
+                    company: "Acme Corp",
+                    location: "London, UK",
+                    startDate: "Jan 2021",
+                    endDate: "Present",
+                    bullets: [
+                        "Led a team of 5 to deliver a modular SwiftUI architecture.",
+                        "Improved app start time by 35% using lazy loading and caching.",
+                        "Drove accessibility compliance (WCAG 2.1 AA)."
+                    ]
+                ),
+                .init(
+                    role: "iOS Engineer",
+                    company: "Globex",
+                    location: "Manchester, UK",
+                    startDate: "Jul 2017",
+                    endDate: "Dec 2020",
+                    bullets: [
+                        "Built offline-first sync using background tasks and Core Data.",
+                        "Implemented CI/CD with unit/UI tests, cutting release time by 40%."
+                    ]
+                )
+            ],
+            education: [
+                .init(
+                    institution: "University of Leeds",
+                    degree: "BSc Computer Science",
+                    startDate: "2013",
+                    endDate: "2016"
+                )
+            ],
+            skills: [
+                "Swift", "SwiftUI", "UIKit", "Combine", "Concurrency",
+                "Core Data", "REST", "GraphQL", "CI/CD", "Testing"
+            ],
+            certifications: [
+                "AWS Certified Cloud Practitioner", "Scrum Master (PSM I)"
+            ],
+            projects: [
+                .init(
+                    name: "OpenWeather Client",
+                    description: "A lightweight, testable Swift package for weather APIs.",
+                    highlights: ["95% test coverage", "Async/await based API"]
+                )
+            ]
+        )
+    }
+}
+

--- a/DraftMe/Core/PDFGenerator.swift
+++ b/DraftMe/Core/PDFGenerator.swift
@@ -1,0 +1,145 @@
+//
+//  Untitled.swift
+//  DraftMe
+//
+//  Created by Kamal Kishor on 15/09/25.
+//
+
+import SwiftUI
+import UIKit
+import PDFKit
+import CoreText
+
+struct PDFGenerator {
+    static private let a4Size = CGSize(width: 595, height: 842) // A4 at 72 DPI
+    static private let pageMargins = UIEdgeInsets(top: 48, left: 48, bottom: 48, right: 48)
+
+    // Legacy rasterizing API (kept for compatibility; not ATS-optimal).
+    static func generatePDF<V: View>(from views: [V], fileURL: URL) {
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: a4Size))
+        let data = renderer.pdfData { context in
+            for view in views {
+                let hostingController = UIHostingController(rootView: view)
+                hostingController.view.frame = CGRect(origin: .zero, size: a4Size)
+                context.beginPage()
+                hostingController.view.layer.render(in: context.cgContext)
+            }
+        }
+        try? data.write(to: fileURL)
+    }
+
+    // ATS-friendly: text stays selectable and searchable.
+    static func generatePDF(from resume: Resume, fileName: String) -> URL? {
+        let docURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        let outURL = (docURL ?? URL(fileURLWithPath: NSTemporaryDirectory())).appendingPathComponent(fileName)
+
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: a4Size))
+        let data = renderer.pdfData { ctx in
+            let contentRect = CGRect(
+                x: pageMargins.left,
+                y: pageMargins.top,
+                width: a4Size.width - pageMargins.left - pageMargins.right,
+                height: a4Size.height - pageMargins.top - pageMargins.bottom
+            )
+
+            let attributed = makeAttributedResume(resume)
+            var framesetter = CTFramesetterCreateWithAttributedString(attributed as CFAttributedString)
+            var currentRange = CFRange(location: 0, length: 0)
+            var done = false
+
+            while !done {
+                ctx.beginPage()
+                let path = CGMutablePath()
+                path.addRect(contentRect)
+                let frame = CTFramesetterCreateFrame(framesetter, currentRange, path, nil)
+                if let context = UIGraphicsGetCurrentContext() {
+                    context.textMatrix = .identity
+                    context.translateBy(x: 0, y: a4Size.height)
+                    context.scaleBy(x: 1.0, y: -1.0)
+                }
+                CTFrameDraw(frame, UIGraphicsGetCurrentContext()!)
+
+                let visibleRange = CTFrameGetVisibleStringRange(frame)
+                currentRange = CFRange(location: visibleRange.location + visibleRange.length, length: 0)
+                if currentRange.location >= attributed.length {
+                    done = true
+                }
+            }
+        }
+
+        do {
+            try data.write(to: outURL)
+            return outURL
+        } catch {
+            print("PDF write failed: \(error)")
+            return nil
+        }
+    }
+
+    private static func makeAttributedResume(_ resume: Resume) -> NSAttributedString {
+        let bodyFont = UIFont.systemFont(ofSize: 11)
+        let headerFont = UIFont.boldSystemFont(ofSize: 20)
+        let subHeaderFont = UIFont.systemFont(ofSize: 12, weight: .semibold)
+        let bold = UIFont.boldSystemFont(ofSize: 11)
+
+        let para = NSMutableParagraphStyle()
+        para.lineSpacing = 2
+        para.paragraphSpacing = 6
+
+        let bodyAttrs: [NSAttributedString.Key: Any] = [
+            .font: bodyFont,
+            .paragraphStyle: para
+        ]
+
+        let builder = NSMutableAttributedString()
+
+        // Header
+        builder.append(NSAttributedString(string: resume.basics.fullName + "\n", attributes: [.font: headerFont]))
+        builder.append(NSAttributedString(string: resume.basics.title + "\n\n", attributes: [.font: subHeaderFont]))
+        let contacts = [resume.basics.email, resume.basics.phone, resume.basics.location, resume.basics.website, resume.basics.linkedin, resume.basics.github]
+            .filter { !$0.isEmpty }
+            .joined(separator: " • ")
+        builder.append(NSAttributedString(string: contacts + "\n\n", attributes: bodyAttrs))
+
+        // Summary
+        builder.append(NSAttributedString(string: "PROFESSIONAL SUMMARY\n", attributes: [.font: subHeaderFont]))
+        builder.append(NSAttributedString(string: resume.summary + "\n\n", attributes: bodyAttrs))
+
+        // Experience
+        builder.append(NSAttributedString(string: "EXPERIENCE\n", attributes: [.font: subHeaderFont]))
+        for exp in resume.experience {
+            builder.append(NSAttributedString(string: "\(exp.role) – \(exp.company)\n", attributes: [.font: bold]))
+            builder.append(NSAttributedString(string: "\(exp.location) • \(exp.startDate) – \(exp.endDate)\n", attributes: bodyAttrs))
+            for bullet in exp.bullets where !bullet.isEmpty {
+                builder.append(NSAttributedString(string: "• \(bullet)\n", attributes: bodyAttrs))
+            }
+            builder.append(NSAttributedString(string: "\n", attributes: bodyAttrs))
+        }
+
+        // Skills
+        if !resume.skills.isEmpty {
+            builder.append(NSAttributedString(string: "SKILLS\n", attributes: [.font: subHeaderFont]))
+            builder.append(NSAttributedString(string: resume.skills.joined(separator: ", ") + "\n\n", attributes: bodyAttrs))
+        }
+
+        // Certifications
+        if !resume.certifications.isEmpty {
+            builder.append(NSAttributedString(string: "CERTIFICATIONS\n", attributes: [.font: subHeaderFont]))
+            for cert in resume.certifications {
+                builder.append(NSAttributedString(string: "• \(cert)\n", attributes: bodyAttrs))
+            }
+            builder.append(NSAttributedString(string: "\n", attributes: bodyAttrs))
+        }
+
+        // Education
+        if !resume.education.isEmpty {
+            builder.append(NSAttributedString(string: "EDUCATION\n", attributes: [.font: subHeaderFont]))
+            for edu in resume.education {
+                builder.append(NSAttributedString(string: "\(edu.institution)\n", attributes: [.font: bold]))
+                builder.append(NSAttributedString(string: "\(edu.degree) • \(edu.startDate) – \(edu.endDate)\n\n", attributes: bodyAttrs))
+            }
+        }
+
+        return builder
+    }
+}

--- a/DraftMe/Features/Canvas/CanvasView.swift
+++ b/DraftMe/Features/Canvas/CanvasView.swift
@@ -10,12 +10,343 @@ import SwiftUI
 struct CanvasView: View {
     
     @State var model: CanvasViewModel
+    enum Mode: String, CaseIterable, Identifiable { case edit, styled, ats; var id: String { rawValue } }
+    @State private var mode: Mode = .edit
+    @State private var newSkill: String = ""
+    @State private var newCert: String = ""
     
     init(model: CanvasViewModel) {
         self.model = model
     }
     
     var body: some View {
-        Text("CanvasView")
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Export PDF") {
+                        exportResume()
+                    }
+                    .foregroundStyle(Color.primary)
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Picker("Mode", selection: $mode) {
+                        Text("Edit").tag(Mode.edit)
+                        Text("Styled").tag(Mode.styled)
+                        Text("ATS").tag(Mode.ats)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 260)
+                }
+            }
+    }
+    
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(model.resume.basics.fullName)
+                    .font(.title).bold()
+                Text(model.resume.basics.title)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(model.resume.basics.email)
+                Text(model.resume.basics.phone)
+                Text(model.resume.basics.location)
+                Text(model.resume.basics.website)
+                Text(model.resume.basics.linkedin)
+                Text(model.resume.basics.github)
+            }
+            .font(.footnote)
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Resume header with contact information")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch mode {
+        case .edit: editForm
+        case .styled: styledPreview
+        case .ats: atsPreview
+        }
+    }
+
+    private var editForm: some View {
+        Form {
+            Section("Basics") {
+                TextField("Full Name", text: $model.resume.basics.fullName)
+                TextField("Title", text: $model.resume.basics.title)
+                TextField("Email", text: $model.resume.basics.email)
+                TextField("Phone", text: $model.resume.basics.phone)
+                TextField("Location", text: $model.resume.basics.location)
+                TextField("Website", text: $model.resume.basics.website)
+                TextField("LinkedIn", text: $model.resume.basics.linkedin)
+                TextField("GitHub", text: $model.resume.basics.github)
+            }
+
+            Section("Professional Summary") {
+                TextEditor(text: $model.resume.summary)
+                    .frame(minHeight: 120)
+            }
+
+            Section("Experience") {
+                ForEach($model.resume.experience) { $exp in
+                    VStack(alignment: .leading) {
+                        TextField("Role", text: $exp.role)
+                        TextField("Company", text: $exp.company)
+                        TextField("Location", text: $exp.location)
+                        HStack {
+                            TextField("Start Date", text: $exp.startDate)
+                            Text("–")
+                            TextField("End Date", text: $exp.endDate)
+                        }
+                        ForEach(exp.bullets.indices, id: \.self) { i in
+                            TextField("Bullet #\(i+1)", text: Binding(
+                                get: { exp.bullets[i] },
+                                set: { exp.bullets[i] = $0 }
+                            ))
+                        }
+                    }
+                }
+                .onDelete(perform: model.removeExperience)
+                Button("Add Experience") { model.addExperience() }
+            }
+
+            Section("Skills") {
+                HStack {
+                    TextField("Add skill", text: $newSkill)
+                    Button("Add") { model.addSkill(newSkill); newSkill = "" }
+                        .disabled(newSkill.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                if !model.resume.skills.isEmpty {
+                    ForEach(Array(model.resume.skills.enumerated()), id: \.offset) { idx, skill in
+                        Text(skill)
+                    }
+                    .onDelete(perform: model.removeSkill)
+                }
+            }
+
+            Section("Certifications") {
+                HStack {
+                    TextField("Add certification", text: $newCert)
+                    Button("Add") { model.addCertification(newCert); newCert = "" }
+                        .disabled(newCert.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                if !model.resume.certifications.isEmpty {
+                    ForEach(Array(model.resume.certifications.enumerated()), id: \.offset) { idx, cert in
+                        Text(cert)
+                    }
+                    .onDelete(perform: model.removeCertification)
+                }
+            }
+
+            Section("Education") {
+                ForEach($model.resume.education) { $edu in
+                    VStack(alignment: .leading) {
+                        TextField("Institution", text: $edu.institution)
+                        TextField("Degree", text: $edu.degree)
+                        HStack {
+                            TextField("Start", text: $edu.startDate)
+                            Text("–")
+                            TextField("End", text: $edu.endDate)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var atsPreview: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionHeader("Professional Summary")
+                Text(model.resume.summary)
+                    .font(.body)
+                Divider()
+
+                sectionHeader("Experience")
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(model.resume.experience) { exp in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("\(exp.role) – \(exp.company)").bold()
+                            Text("\(exp.location) • \(exp.startDate) – \(exp.endDate)")
+                                .foregroundStyle(.secondary)
+                                .font(.subheadline)
+                            VStack(alignment: .leading, spacing: 2) {
+                                ForEach(exp.bullets, id: \.self) { bullet in
+                                    HStack(alignment: .top, spacing: 6) {
+                                        Text("•")
+                                        Text(bullet)
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+                Divider()
+
+                sectionHeader("Skills")
+                Text(model.resume.skills.joined(separator: ", "))
+                Divider()
+
+                sectionHeader("Certifications")
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(model.resume.certifications, id: \.self) { cert in
+                        Text("• \(cert)")
+                    }
+                }
+                Divider()
+
+                sectionHeader("Education")
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(model.resume.education) { edu in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(edu.institution).bold()
+                            Text("\(edu.degree) • \(edu.startDate) – \(edu.endDate)")
+                                .foregroundStyle(.secondary)
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var styledPreview: some View {
+        ScrollView {
+            HStack(alignment: .top, spacing: 0) {
+                // Left rail
+                VStack(alignment: .leading, spacing: 16) {
+                    // Avatar placeholder / color block
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(LinearGradient(colors: [.blue.opacity(0.85), .blue.opacity(0.45)], startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(height: 120)
+
+                    // Contact
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("CONTACT").font(.footnote.weight(.semibold)).foregroundStyle(.secondary)
+                        Group {
+                            Text(model.resume.basics.email)
+                            Text(model.resume.basics.phone)
+                            Text(model.resume.basics.location)
+                            if !model.resume.basics.website.isEmpty { Text(model.resume.basics.website) }
+                            if !model.resume.basics.linkedin.isEmpty { Text(model.resume.basics.linkedin) }
+                            if !model.resume.basics.github.isEmpty { Text(model.resume.basics.github) }
+                        }.font(.footnote)
+                    }
+
+                    // Skills
+                    if !model.resume.skills.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("SKILLS").font(.footnote.weight(.semibold)).foregroundStyle(.secondary)
+                            VStack(alignment: .leading, spacing: 6) {
+                                ForEach(model.resume.skills, id: \.self) { skill in
+                                    Text(skill)
+                                        .font(.footnote)
+                                        .padding(.horizontal, 8).padding(.vertical, 4)
+                                        .background(Color.blue.opacity(0.08))
+                                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                                }
+                            }
+                        }
+                    }
+
+                    // Certifications
+                    if !model.resume.certifications.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("CERTIFICATIONS").font(.footnote.weight(.semibold)).foregroundStyle(.secondary)
+                            ForEach(model.resume.certifications, id: \.self) { cert in
+                                Text("• \(cert)").font(.footnote)
+                            }
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+                .frame(width: 220)
+                .padding(16)
+                .background(Color(.systemGray6))
+
+                // Right main
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(model.resume.basics.fullName).font(.title2.bold())
+                        Text(model.resume.basics.title).font(.headline).foregroundStyle(.secondary)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("PROFESSIONAL SUMMARY").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+                        Text(model.resume.summary)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("EXPERIENCE").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+                        ForEach(model.resume.experience) { exp in
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack { Text(exp.role).bold(); Text("•"); Text(exp.company).bold() }
+                                Text("\(exp.location) • \(exp.startDate) – \(exp.endDate)").font(.footnote).foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    ForEach(exp.bullets, id: \.self) { bullet in
+                                        HStack(alignment: .top, spacing: 6) { Text("•"); Text(bullet) }
+                                    }
+                                }
+                            }.padding(.vertical, 4)
+                        }
+                    }
+
+                    if !model.resume.education.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("EDUCATION").font(.subheadline.weight(.semibold)).foregroundStyle(.secondary)
+                            ForEach(model.resume.education) { edu in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(edu.institution).bold()
+                                    Text("\(edu.degree) • \(edu.startDate) – \(edu.endDate)").font(.footnote).foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .padding(20)
+            }
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .accessibilityElement(children: .contain)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private func exportResume() {
+        let fileName = SafeFileName.sanitized("\(model.resume.basics.fullName) - CV.pdf")
+        if let url = PDFGenerator.generatePDF(from: model.resume, fileName: fileName) {
+            print("Saved PDF at: \(url.path)")
+        }
+    }
+}
+
+private enum SafeFileName {
+    static func sanitized(_ raw: String) -> String {
+        let invalid = CharacterSet(charactersIn: "\\/:*?\"<>|\n\r")
+        let replaced = raw.unicodeScalars.map { invalid.contains($0) ? "-" : String($0) }.joined()
+        return replaced.replacingOccurrences(of: " ", with: " ")
     }
 }

--- a/DraftMe/Features/Canvas/CanvasViewModel.swift
+++ b/DraftMe/Features/Canvas/CanvasViewModel.swift
@@ -9,6 +9,38 @@ import Foundation
 
 @Observable
 final class CanvasViewModel {
-    
-    init() {}
+    var state: CanvasState = .editing
+    var resume: Resume
+
+    init(resume: Resume = .placeholder) {
+        self.resume = resume
+    }
+
+    func addExperience() {
+        resume.experience.append(
+            .init(role: "Job Title", company: "Company", location: "City, Country", startDate: "Start", endDate: "End", bullets: ["Achievement or responsibility."])
+        )
+    }
+
+    func removeExperience(at indexSet: IndexSet) {
+        resume.experience.remove(atOffsets: indexSet)
+    }
+
+    func addSkill(_ skill: String) {
+        guard !skill.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        resume.skills.append(skill)
+    }
+
+    func removeSkill(at indexSet: IndexSet) {
+        resume.skills.remove(atOffsets: indexSet)
+    }
+
+    func addCertification(_ cert: String) {
+        guard !cert.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        resume.certifications.append(cert)
+    }
+
+    func removeCertification(at indexSet: IndexSet) {
+        resume.certifications.remove(atOffsets: indexSet)
+    }
 }

--- a/DraftMe/Features/Home/HomeView.swift
+++ b/DraftMe/Features/Home/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     
     @State var model: HomeViewModel
+    @State var selectedMenu: MenuView.Destination = .new
     
     init(model: HomeViewModel) {
         self.model = model
@@ -17,10 +18,12 @@ struct HomeView: View {
     
     var body: some View {
         NavigationSplitView {
-            MenuView()
+            MenuView(selected: $selectedMenu)
                 .navigationSplitViewColumnWidth(min: 180, ideal: 200)
         } detail: {
-            TemplatesView(viewModel: .init())
+            withAnimation(.easeIn(duration: 0.5)) {
+                selectedMenu.destination
+            }
         }
     }
 }

--- a/DraftMe/Features/Menu/MenuView.swift
+++ b/DraftMe/Features/Menu/MenuView.swift
@@ -8,19 +8,36 @@ import SwiftUI
 
 struct MenuView: View {
     
+    @Binding var selected: Destination
+    
     var body: some View {
-        List(MenuItem.allCases, id: \.self) { menu in
-            Text(menu.rawValue)
+        List(Destination.allCases, id: \.self) { destination in
+            Text(destination.rawValue)
                 .font(.body)
                 .foregroundStyle(Color.primary)
+                .onTapGesture {
+                    self.selected = destination
+                }
         }
     }
 }
 
 extension MenuView {
-    enum MenuItem: String, CaseIterable {
+    enum Destination: String, CaseIterable {
         case new = "New Document"
         case templates = "Open"
         case settings = "Settings"
+        
+        @ViewBuilder
+        var destination: some View {
+            switch self {
+            case .new:
+                CanvasView(model: .init())
+            case .templates:
+                TemplatesView(model: .init())
+            case .settings:
+                EmptyView()
+            }
+        }
     }
 }

--- a/DraftMe/Features/Templates/TemplateView.swift
+++ b/DraftMe/Features/Templates/TemplateView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct TemplatesView: View {
     
-    @State var viewModel: TemplatesViewModel
+    @State var model: TemplatesViewModel
     @State var orientation: UIDeviceOrientation = .portrait
     
-    init(viewModel: TemplatesViewModel) {
-        self.viewModel = viewModel
+    init(model: TemplatesViewModel) {
+        self.model = model
     }
     
     var body: some View {
@@ -48,9 +48,9 @@ struct TemplatesView: View {
 
 #if DEBUG
 #Preview("Portrait") {
-    TemplatesView(viewModel: .init())
+    TemplatesView(model: .init())
 }
 #Preview("Landscape Left", traits: .landscapeLeft) {
-    TemplatesView(viewModel: .init())
+    TemplatesView(model: .init())
 }
 #endif


### PR DESCRIPTION
- Core model: Added `Resume` and related types at `DraftMe/Core/Models/Resume.swift`.
- Canvas UI: Added Edit, Styled, and ATS modes with a full edit form and previews.
- PDF export: Implemented ATS-friendly CoreText export in `Core/PDFGenerator.swift`; toolbar button now “Export PDF” and saves to Documents.
- ViewModel: Wired `CanvasViewModel` to `Resume` with add/remove helpers.
- Fixes: Removed duplicate `Resume` in `CanvasViewModel.swift` and corrected exp
ort filename interpolation.

[Alex Johnson - CV.pdf](https://github.com/user-attachments/files/22565289/Alex.Johnson.-.CV.pdf)
